### PR TITLE
Block fixup commit merge

### DIFF
--- a/.github/workflows/fixup_check.yml
+++ b/.github/workflows/fixup_check.yml
@@ -1,0 +1,10 @@
+name: Git Checks
+on: [ pull_request ]
+jobs:
+  block-fixup:
+    name: Block fixup check
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2.0.0
+    - name: Block Fixup Commit Merge
+      uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
Add GitHub workflow that blocks PRs if they contain fixup commit