### PR TITLE
Span Exporter refactoring

### DIFF
--- a/core/configuration/dt_config_provider.go
+++ b/core/configuration/dt_config_provider.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/url"
+	"strings"
 
 	"core/configuration/internal/util"
 )
@@ -88,6 +89,9 @@ func loadConfiguration(configFileReader configFileReader) (*DtConfiguration, err
 		LoggingDestination:       LoggingDestination(util.GetStringFromEnvWithDefault("DT_LOGGING_DESTINATION", string(fileConfig.Logging.Destination))),
 		LoggingFlags:             util.GetStringFromEnvWithDefault("DT_LOGGING_GO_FLAGS", fileConfig.Logging.Go.Flags),
 	}
+
+	// A potential trailing forward slash in BaseUrl value must be gracefully handled
+	config.BaseUrl = strings.TrimSuffix(config.BaseUrl, "/")
 
 	setDefaultConfigValues(config)
 	if validationErr := validateConfiguration(config); validationErr != nil {

--- a/core/configuration/dt_config_provider_test.go
+++ b/core/configuration/dt_config_provider_test.go
@@ -121,3 +121,11 @@ func TestConfigurationViaEnvironment_NonEmptyConfigFile(t *testing.T) {
 	assert.Equal(t, config.LoggingDestination, LoggingDestination_Stdout)
 	assert.Equal(t, config.LoggingFlags, "flag1=true,flag2=false")
 }
+
+func TestHandlingBaseUrlWithForwardSlash(t *testing.T) {
+	mockConfigFileReader := createMockConfigFileReaderWithRequiredFields()
+	mockConfigFileReader.fileConfig.Connection.BaseUrl = "http://localhost:8080/"
+	config, _ := loadConfiguration(mockConfigFileReader)
+
+	assert.Equal(t, config.BaseUrl, "http://localhost:8080")
+}

--- a/core/trace/dt_span_exporter.go
+++ b/core/trace/dt_span_exporter.go
@@ -141,7 +141,7 @@ func (e *dtSpanExporterImpl) performHttpRequest(req *http.Request, t exportType)
 		}
 	}
 
-	e.updateTimeouts(t)
+	e.setTimeouts(t)
 
 	start := time.Now()
 	resp, err = e.client.Do(req)
@@ -163,8 +163,8 @@ func (e *dtSpanExporterImpl) performHttpRequest(req *http.Request, t exportType)
 	return resp, err
 }
 
-// updateTimeouts updates connection and data timeouts for HTTP client
-func (e *dtSpanExporterImpl) updateTimeouts(t exportType) {
+// setTimeouts updates connection and data timeouts for HTTP client
+func (e *dtSpanExporterImpl) setTimeouts(t exportType) {
 	var conn, data int64
 	if t == exportTypeForceFlush {
 		conn = configuration.DefaultFlushExportConnTimeoutMs

--- a/core/trace/dt_span_exporter_test.go
+++ b/core/trace/dt_span_exporter_test.go
@@ -103,11 +103,11 @@ func TestDtSpanExporterPerformHTTPRequestWithReachedFlushOperationTimeout(t *tes
 func TestDtSpanExporterUpdateHttpClientTimeouts(t *testing.T) {
 	exporter := newDtSpanExporter(testConfig).(*dtSpanExporterImpl)
 
-	exporter.updateTimeouts(exportTypeForceFlush)
+	exporter.setTimeouts(exportTypeForceFlush)
 	require.Equal(t, exporter.dialer.Timeout, time.Millisecond*time.Duration(configuration.DefaultFlushExportConnTimeoutMs))
 	require.Equal(t, exporter.client.Timeout, time.Millisecond*time.Duration(configuration.DefaultFlushExportConnTimeoutMs+configuration.DefaultFlushExportDataTimeoutMs))
 
-	exporter.updateTimeouts(exportTypePeriodic)
+	exporter.setTimeouts(exportTypePeriodic)
 	require.Equal(t, exporter.dialer.Timeout, time.Millisecond*time.Duration(configuration.DefaultRegularExportConnTimeoutMs))
 	require.Equal(t, exporter.client.Timeout, time.Millisecond*time.Duration(configuration.DefaultRegularExportConnTimeoutMs+configuration.DefaultRegularExportDataTimeoutMs))
 }


### PR DESCRIPTION
Added gracefully handling of trailing slash in BaseUrl
Renamed `updateTimeouts` on `setTimeouts`