### PR TITLE
Log dev version warning even if logger is disabled or not configured

### DIFF
--- a/core/internal/logger/logger.go
+++ b/core/internal/logger/logger.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/dynatrace-oss/opentelemetry-exporter-go/core/configuration"
+	"github.com/dynatrace-oss/opentelemetry-exporter-go/core/internal/version"
 )
 
 type debugLogFlags map[string]bool
@@ -84,6 +85,16 @@ func (p *dtLogger) log(kind logKind, component string, msg string) {
 type ComponentLogger struct {
 	componentName    string
 	debugFlagEnabled bool
+}
+
+func init() {
+	// We do not use the internalDtLogger for this since it might never be correctly configured.
+	// We ensure this line is always printed to stderr if a development version of the library is used.
+	if version.Version == "0.0.0" {
+		fmt.Fprintf(os.Stderr,
+			"[Dynatrace] This is a development version (%s) and not intended for use in production environments.\n",
+			version.FullVersion)
+	}
 }
 
 func NewComponentLogger(componentName string) *ComponentLogger {

--- a/core/internal/logger/startup_banner.go
+++ b/core/internal/logger/startup_banner.go
@@ -29,10 +29,6 @@ func logStartupBanner(config *configuration.DtConfiguration) {
 
 	logger.Infof("OneAgent ODIN Go version .... %s, build date %s", version.FullVersion, version.BuildDate)
 
-	if version.Version == "0.0.0" {
-		logger.Infof("This is a development version (%s) and not intended for use in production environments.", version.FullVersion)
-	}
-
 	exePath, err := os.Executable()
 	if err == nil {
 		logger.Infof("Executable path ............. %s", exePath)


### PR DESCRIPTION
The warning is logged to stderr immediately if a development version is used, even if the logger cannot be configured or is manually disabled through the configuration.

The warning is logged before the startup banner.