### PR TITLE
Retry export on connection reset when nested error is EOF

### DIFF
--- a/core/trace/dt_span_exporter.go
+++ b/core/trace/dt_span_exporter.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -42,10 +43,6 @@ const cSpansPath = "/odin/v1/spans"
 
 const cMaxSizeWarning = 1 * 1024 * 1024 // 1 MB
 const cMaxSizeSend = 64 * 1024 * 1024   // 64 MB
-
-// For connection resets, retry only if the send operation failed within this time
-// limit. Otherwise, we assume the backend is overloaded and do not retry.
-const cConnectionResetTimeLimit = 300 * time.Millisecond
 
 var errNotAuthorizedRequest = errors.New("Span Exporter is not authorized to send spans")
 
@@ -110,7 +107,12 @@ func (e *dtSpanExporterImpl) export(ctx context.Context, t exportType, spans dtS
 		e.logger.Warnf("Size of serialized spans reached %d bytes", serializedSpansLen)
 	}
 
-	resp, err := e.exportWithRetry(ctx, t, serializedSpans)
+	reqBody := bytes.NewReader(serializedSpans)
+	req, err := e.newRequest(ctx, reqBody)
+	if err != nil {
+		return err
+	}
+	resp, err := e.performHttpRequest(req, t)
 	if err != nil {
 		return err
 	}
@@ -125,38 +127,10 @@ func (e *dtSpanExporterImpl) export(ctx context.Context, t exportType, spans dtS
 		return errors.New("unexpected response code: " + strconv.Itoa(resp.StatusCode))
 	}
 
-	e.logger.Debug("Export successful")
 	return nil
 }
 
-func (e *dtSpanExporterImpl) exportWithRetry(ctx context.Context, t exportType, serializedSpans []byte) (*http.Response, error) {
-	reqBody := bytes.NewBuffer(serializedSpans)
-	req, err := e.newRequest(ctx, reqBody)
-	if err != nil {
-		return nil, err
-	}
-	exportStartTime := time.Now()
-	resp, err := e.performHttpRequest(req, t)
-	exportDuration := time.Since(exportStartTime)
-
-	// Retry once if the connection was reset by the backend and the request took less than cConnectionResetTimeLimit.
-	if errors.Is(err, io.EOF) {
-		if exportDuration < cConnectionResetTimeLimit {
-			e.logger.Warn("Got EOF during export, retrying once")
-			reqBody := bytes.NewBuffer(serializedSpans)
-			req, err := e.newRequest(ctx, reqBody)
-			if err != nil {
-				return nil, err
-			}
-			return e.performHttpRequest(req, t)
-		} else {
-			e.logger.Warnf("Got EOF during export, but request took too long (%v), not retrying", exportDuration)
-		}
-	}
-	return resp, err
-}
-
-func (e *dtSpanExporterImpl) newRequest(ctx context.Context, body io.Reader) (*http.Request, error) {
+func (e *dtSpanExporterImpl) newRequest(ctx context.Context, body *bytes.Reader) (*http.Request, error) {
 	req, err := http.NewRequestWithContext(ctx, "POST", e.config.BaseUrl+cSpansPath, body)
 	if err != nil {
 		e.logger.Errorf("Can not create HTTP request: %s", err)
@@ -168,6 +142,18 @@ func (e *dtSpanExporterImpl) newRequest(ctx context.Context, body io.Reader) (*h
 	req.Header.Set("User-Agent", fmt.Sprintf("odin-go/%s %#016x %s",
 		version.FullVersion, e.config.AgentId, e.config.Tenant))
 	req.Header.Set("Accept", "*/*; q=0")
+	// Setting just the header Idempotency-Key with an empty value ensures that the request is
+	// treated as idempotent but the header is not sent over the wire. See net/http/transport.go
+	req.Header.Set("Idempotency-Key", "")
+
+	// GetBody must be set to allow for automatic retries. See net/http/transport.go
+	req.GetBody = func() (io.ReadCloser, error) {
+		_, err := body.Seek(0, io.SeekStart)
+		if err != nil {
+			return nil, err
+		}
+		return ioutil.NopCloser(body), nil
+	}
 
 	return req, nil
 }

--- a/core/trace/dt_span_exporter_test.go
+++ b/core/trace/dt_span_exporter_test.go
@@ -45,7 +45,7 @@ func TestDtSpanExporterVerifyNewRequest(t *testing.T) {
 	}
 
 	exporter := newDtSpanExporter(config).(*dtSpanExporterImpl)
-	req, err := exporter.newRequest(context.Background(), bytes.NewBuffer([]byte{1, 2, 3, 4, 5}))
+	req, err := exporter.newRequest(context.Background(), bytes.NewReader([]byte{1, 2, 3, 4, 5}))
 
 	require.NoError(t, err)
 	require.Equal(t, req.Method, "POST")
@@ -54,6 +54,7 @@ func TestDtSpanExporterVerifyNewRequest(t *testing.T) {
 	require.Equal(t, req.Header.Get("Authorization"), "Dynatrace testDtToken")
 	require.Equal(t, req.Header.Get("User-Agent"), fmt.Sprintf("odin-go/%s 0x000000000000000a testTenant", version.FullVersion))
 	require.Equal(t, req.Header.Get("Accept"), "*/*; q=0")
+	require.Equal(t, req.Header.Get("Idempotency-Key"), "")
 	require.EqualValues(t, req.ContentLength, 5)
 
 	body, err := ioutil.ReadAll(req.Body)
@@ -69,6 +70,7 @@ func TestDtSpanExporterPerformHTTPRequest(t *testing.T) {
 		require.Equal(t, req.Header.Get("Authorization"), "Dynatrace testDtToken")
 		require.Equal(t, req.Header.Get("User-Agent"), fmt.Sprintf("odin-go/%s 0x000000000000000a testDtTenant", version.FullVersion))
 		require.Equal(t, req.Header.Get("Accept"), "*/*; q=0")
+		require.Equal(t, req.Header.Get("Idempotency-Key"), "")
 		require.EqualValues(t, req.ContentLength, 3)
 
 		body, err := ioutil.ReadAll(req.Body)
@@ -92,7 +94,7 @@ func TestDtSpanExporterPerformHTTPRequest(t *testing.T) {
 	}
 
 	exporter := newDtSpanExporter(config).(*dtSpanExporterImpl)
-	req, _ := exporter.newRequest(context.Background(), bytes.NewBuffer([]byte{10, 20, 30}))
+	req, _ := exporter.newRequest(context.Background(), bytes.NewReader([]byte{10, 20, 30}))
 	resp, err := exporter.performHttpRequest(req, exportTypePeriodic)
 	require.Equal(t, resp.StatusCode, http.StatusOK)
 	require.NoError(t, err)
@@ -121,7 +123,7 @@ func TestDtSpanExporterPerformHTTPRequestWithReachedFlushOperationTimeout(t *tes
 	}
 
 	exporter := newDtSpanExporter(config).(*dtSpanExporterImpl)
-	req, _ := exporter.newRequest(context.Background(), bytes.NewBuffer([]byte{10, 20, 30}))
+	req, _ := exporter.newRequest(context.Background(), bytes.NewReader([]byte{10, 20, 30}))
 	resp, err := exporter.performHttpRequest(req, exportTypeForceFlush)
 	require.Nil(t, resp)
 	require.ErrorContains(t, err, "context deadline exceeded (Client.Timeout exceeded while awaiting headers")


### PR DESCRIPTION
Initially, I just checked if the error returned from the HTTP request was equal to the `EOF` error. This is a mistake, since the HTTP client `Do` method, which we use to send requests, does not return the `EOF` error directly, but wraps it. Using `errors.Is()` instead ensures that the error is unwrapped and compared instead.