### PR TITLE
Fix reading dtconfig.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 
 # Go workspace file
 go.work
+
+# IDE miscellaneous
+.idea/

--- a/core/configuration/dt_config_file_reader.go
+++ b/core/configuration/dt_config_file_reader.go
@@ -58,7 +58,7 @@ type jsonConfigFileReader struct {
 // ReadConfigFromFile looks for a config file "dtconfig.json" in the current directory and attempts to parse it.
 // Returns an error if the file can't be read or the parsing fails.
 func (j *jsonConfigFileReader) readConfigFromFile() (fileConfig, error) {
-	return j.readConfigFromFileByPath("./dtconfig.json")
+	return j.readConfigFromFileByPath("./serverless_function_source_code/dtconfig.json")
 }
 
 func (j *jsonConfigFileReader) readConfigFromFileByPath(filePath string) (fileConfig, error) {


### PR DESCRIPTION
In GCF (1st and 2nd gen functions) the source code of a function is placed at  `/workspace/serverless_function_source_code` folder, but since the function is started from the parent `/workspace` folder reading the dtconfig.json at "./dtconfig.json" path is not working.
The PR fixes it by reading the file from ./serverless_function_source_code/dtconfig.json


