### PR TITLE
Improve reading config file

### DIFF
--- a/core/configuration/dt_config_file_reader.go
+++ b/core/configuration/dt_config_file_reader.go
@@ -64,6 +64,10 @@ func (j *jsonConfigFileReader) readConfigFromFile() (fileConfig, error) {
 }
 
 func configFilePath() string {
+	if configFilePathFromEnv := os.Getenv("DT_CONFIG_FILE_PATH"); configFilePathFromEnv != "" {
+		return configFilePathFromEnv
+	}
+
 	// When running in a Google Cloud Functions Go runtime, we need to find the config file at a different path.
 	// For reference on the K_SERVICE environment variable, see:
 	// https://cloud.google.com/functions/docs/configuring/env-var#runtime_environment_variables_set_automatically

--- a/core/configuration/dt_config_file_reader_test.go
+++ b/core/configuration/dt_config_file_reader_test.go
@@ -15,6 +15,7 @@
 package configuration
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,6 +25,16 @@ func TestJsonConfigFileReader_NoErrorForValidFile(t *testing.T) {
 	reader := jsonConfigFileReader{}
 	_, err := reader.readConfigFromFileByPath("./testdata/dtconfig_test_valid.json")
 	assert.NoError(t, err)
+}
+
+func TestJsonConfigFileReader_CustomPath(t *testing.T) {
+	os.Setenv("DT_CONFIG_FILE_PATH", "./testdata/subfolder/dtconfig_test_valid.json")
+	defer os.Unsetenv("DT_CONFIG_FILE_PATH")
+
+	reader := jsonConfigFileReader{}
+	cfg, err := reader.readConfigFromFile()
+	assert.NoError(t, err)
+	assert.Equal(t, "subfolder_config", cfg.Tenant)
 }
 
 func TestJsonConfigFileReader_ErrorForInvalidFile(t *testing.T) {

--- a/core/configuration/testdata/subfolder/dtconfig_test_valid.json
+++ b/core/configuration/testdata/subfolder/dtconfig_test_valid.json
@@ -1,0 +1,29 @@
+{
+    "AgentActive": true,
+    "ClusterID": 12345,
+    "Tenant": "subfolder_config",
+    "Connection": {
+        "AuthToken": "dt0a01.schnitzel.xsdffdedr",
+        "BaseUrl": "https://ag.xyz.com"
+    },
+    "RUM": {
+        "ClientIpHeaders": [
+            "x-forwarded-for"
+        ]
+    },
+    "Testability": {
+        "SpanProcessingIntervalMs": 3000,
+        "KeepAliveIntervalMs": 30000,
+        "MetricCollectionIntervalMs": 10000,
+        "MetricCollectionsPerExport": 6
+    },
+    "Logging": {
+        "Destination": "stderr",
+        "Go": {
+            "Flags": "Exporter=true,Propagator=false"
+        }
+    },
+    "Debug": {
+        "AddStackOnStart": true
+    }
+}


### PR DESCRIPTION
This PR introduces 2 changes:

1. Allows specifying the config file path via environment variable.
2. When running in Google Cloud Functions, uses the default path `./serverless_function_source_code/dtconfig.json` rather than `./dtconfig.json`.

As already discussed with @Bataran, this makes PR #37 redundant, and will be closed.